### PR TITLE
feat: implement client pages

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+
+export function useAuth() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["/api/auth/user"],
+    queryFn: () => apiRequest("/api/auth/user"),
+  });
+
+  return {
+    user: data,
+    isAuthenticated: !!data,
+    isLoading,
+  };
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,0 +1,38 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();
+
+export async function apiRequest(
+  methodOrPath: string,
+  pathOrMethod?: string,
+  data?: any
+) {
+  let method = "GET";
+  let path = "";
+
+  if (pathOrMethod && (pathOrMethod.startsWith("/") || pathOrMethod.startsWith("http"))) {
+    method = methodOrPath;
+    path = pathOrMethod;
+  } else {
+    path = methodOrPath;
+    method = pathOrMethod ?? "GET";
+  }
+
+  const res = await fetch(path, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: data ? JSON.stringify(data) : undefined,
+  });
+
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import AdminRevenueDashboard from "@/components/admin-revenue-dashboard";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function AdminDashboard() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <AdminRevenueDashboard />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/events.tsx
+++ b/client/src/pages/events.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import NavigationBar from "@/components/navigation-bar";
+import EventAlertModal from "@/components/event-alert-modal";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function EventsPage() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6 space-y-4">
+        <Button onClick={() => setOpen(true)}>Skep Gebeurtenis Herinnering</Button>
+        <EventAlertModal open={open} onOpenChange={setOpen} />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/export.tsx
+++ b/client/src/pages/export.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import EnhancedExport from "@/components/enhanced-export";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function ExportPage() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <EnhancedExport />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,0 +1,26 @@
+import NavigationBar from "@/components/navigation-bar";
+import StatsCards from "@/components/stats-cards";
+import WishlistSection from "@/components/wishlist-section";
+import AchievementsPanel from "@/components/achievements-panel";
+import SmartRecommendations from "@/components/smart-recommendations";
+import AdvertisementComponent from "@/components/advertisement";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function Home() {
+  const { user } = useAuth();
+
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6 space-y-6">
+        <StatsCards />
+        <SmartRecommendations />
+        <div className="grid gap-6 md:grid-cols-2">
+          <WishlistSection />
+          <AchievementsPanel />
+        </div>
+        <AdvertisementComponent position="inline" />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,0 +1,17 @@
+import { Button } from "@/components/ui/button";
+import AdvertisementComponent from "@/components/advertisement";
+import LanguageSelector from "@/components/language-selector";
+
+export default function Landing() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-6 p-6 text-center">
+      <AdvertisementComponent position="banner" className="w-full max-w-md" />
+      <h1 className="text-3xl font-bold">Welkom by BurkeBooks</h1>
+      <p className="text-muted-foreground">Bestuur jou boekversameling met gemak.</p>
+      <Button onClick={() => (window.location.href = "/api/login")}>
+        Teken In
+      </Button>
+      <LanguageSelector />
+    </div>
+  );
+}

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,0 +1,17 @@
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+import NavigationBar from "@/components/navigation-bar";
+
+export default function NotFound() {
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-8 text-center space-y-4">
+        <h1 className="text-3xl font-bold">404 - Nie Gevind Nie</h1>
+        <Link href="/">
+          <Button>Gaan Huis Toe</Button>
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/premium.tsx
+++ b/client/src/pages/premium.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import PremiumSubscription from "@/components/premium-subscription";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function PremiumPage() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <PremiumSubscription />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/price-alerts.tsx
+++ b/client/src/pages/price-alerts.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import NavigationBar from "@/components/navigation-bar";
+import PriceAlertModal from "@/components/price-alert-modal";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function PriceAlerts() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6 space-y-4">
+        <Button onClick={() => setOpen(true)}>Skep Pryswaarskuwing</Button>
+        <PriceAlertModal isOpen={open} onClose={() => setOpen(false)} />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/price-comparison.tsx
+++ b/client/src/pages/price-comparison.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import WishlistSearch from "@/components/wishlist-search";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function PriceComparison() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <WishlistSearch />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/recommendations.tsx
+++ b/client/src/pages/recommendations.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import SmartRecommendations from "@/components/smart-recommendations";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function RecommendationsPage() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <SmartRecommendations />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/scanner.tsx
+++ b/client/src/pages/scanner.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import NavigationBar from "@/components/navigation-bar";
+import BarcodeScanner from "@/components/barcode-scanner";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function ScannerPage() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6 space-y-4">
+        <Button onClick={() => setOpen(true)}>Open Skaner</Button>
+        <BarcodeScanner open={open} onOpenChange={setOpen} />
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/social.tsx
+++ b/client/src/pages/social.tsx
@@ -1,0 +1,15 @@
+import NavigationBar from "@/components/navigation-bar";
+import SocialFeatures from "@/components/social-features";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function SocialPage() {
+  const { user } = useAuth();
+  return (
+    <>
+      <NavigationBar />
+      <div className="p-6">
+        <SocialFeatures />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add query client and useAuth hook
- build full page components with shared UI and auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find module '@/lib/utils', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a8cd3ef883238ca48be32f804348