### PR TITLE
feat: add serverless entrypoint

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -1,0 +1,7 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import app from "../server/index";
+
+// Express apps are (req, res) handlers – forward directly
+export default (req: VercelRequest, res: VercelResponse) => {
+  return (app as any)(req, res);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "api/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,


### PR DESCRIPTION
## Summary
- add Vercel serverless handler forwarding requests to Express app
- include api directory in TypeScript compilation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find module '@vercel/node' or its corresponding type declarations and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d15c8320832381b67bc3c08cd9fd