### PR TITLE
fix: wire client query client and pages

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ApiError, apiRequest } from "@/lib/queryClient";
+import type { User } from "@shared/schema";
+
+type AuthUser = User | null;
+
+export function useAuth() {
+  const query = useQuery<AuthUser>({
+    queryKey: ["/api/auth/user"],
+    queryFn: async () => {
+      try {
+        const response = await apiRequest("/api/auth/user");
+        const contentType = response.headers.get("content-type") ?? "";
+        if (response.status === 204 || !contentType.includes("application/json")) {
+          return null;
+        }
+        return (await response.json()) as User;
+      } catch (error) {
+        if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    retry: 0,
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+
+  return useMemo(
+    () => ({
+      user: query.data,
+      isAuthenticated: Boolean(query.data),
+      isLoading: query.isLoading,
+      isError: query.isError,
+      error: query.error,
+      refetch: query.refetch,
+    }),
+    [query.data, query.error, query.isError, query.isLoading, query.refetch],
+  );
+}

--- a/client/src/lib/authUtils.ts
+++ b/client/src/lib/authUtils.ts
@@ -1,0 +1,13 @@
+import { ApiError } from "@/lib/queryClient";
+
+export function isUnauthorizedError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 401 || error.status === 403;
+  }
+
+  if (error instanceof Error) {
+    return /unauthorized/i.test(error.message);
+  }
+
+  return false;
+}

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -1,0 +1,101 @@
+export type Language = "af" | "en" | "nl";
+
+export type Translation = {
+  home: string;
+  premium: string;
+  recommendations: string;
+  community: string;
+  scanner: string;
+  export: string;
+  prices: string;
+  alerts: string;
+  eventsPage: string;
+  admin: string;
+  logout: string;
+  welcomeHeadline: string;
+  welcomeSubheading: string;
+  getStarted: string;
+  login: string;
+  discoverFeatures: string;
+  dashboardHeading: string;
+  dashboardSubheading: string;
+  latestBooks: string;
+  emptyLibraryCta: string;
+  refresh: string;
+  tryAgain: string;
+};
+
+export const translations: Record<Language, Translation> = {
+  af: {
+    home: "Tuis",
+    premium: "Premium",
+    recommendations: "Aanbevelings",
+    community: "Gemeenskap",
+    scanner: "Skandeerder",
+    export: "Uitvoer",
+    prices: "Pryse",
+    alerts: "Waarskuwings",
+    eventsPage: "Gebeurtenisse",
+    admin: "Admin",
+    logout: "Teken uit",
+    welcomeHeadline: "Bou jou Afrikaanse boek heelal",
+    welcomeSubheading: "Bestuur jou versameling, ontdek nuwe boeke en bly op hoogte van literêre gebeure in Suid-Afrika.",
+    getStarted: "Begin nou",
+    login: "Teken in",
+    discoverFeatures: "Ontdek funksies",
+    dashboardHeading: "Welkom terug by jou boekkosmos",
+    dashboardSubheading: "Hou tred met jou versameling, AI-aanbevelings en gemeenskapsaktiwiteit.",
+    latestBooks: "Onlangse toevoegings",
+    emptyLibraryCta: "Voeg jou eerste boek by om te begin!",
+    refresh: "Verfris",
+    tryAgain: "Probeer weer",
+  },
+  en: {
+    home: "Home",
+    premium: "Premium",
+    recommendations: "Recommendations",
+    community: "Community",
+    scanner: "Scanner",
+    export: "Export",
+    prices: "Prices",
+    alerts: "Alerts",
+    eventsPage: "Events",
+    admin: "Admin",
+    logout: "Sign out",
+    welcomeHeadline: "Build your Afrikaans book universe",
+    welcomeSubheading: "Manage your collection, discover new titles and stay in sync with literary events across South Africa.",
+    getStarted: "Get started",
+    login: "Log in",
+    discoverFeatures: "Discover features",
+    dashboardHeading: "Welcome back to your library cosmos",
+    dashboardSubheading: "Track your collection, AI suggestions and community activity.",
+    latestBooks: "Latest additions",
+    emptyLibraryCta: "Add your first book to get started!",
+    refresh: "Refresh",
+    tryAgain: "Try again",
+  },
+  nl: {
+    home: "Start",
+    premium: "Premium",
+    recommendations: "Aanbevelingen",
+    community: "Gemeenschap",
+    scanner: "Scanner",
+    export: "Exporteren",
+    prices: "Prijzen",
+    alerts: "Alerts",
+    eventsPage: "Evenementen",
+    admin: "Beheer",
+    logout: "Afmelden",
+    welcomeHeadline: "Bouw je Afrikaanse boekenuniversum",
+    welcomeSubheading: "Beheer je collectie, ontdek nieuwe boeken en volg literaire evenementen in Zuid-Afrika.",
+    getStarted: "Aan de slag",
+    login: "Inloggen",
+    discoverFeatures: "Ontdek functies",
+    dashboardHeading: "Welkom terug bij je bibliotheek kosmos",
+    dashboardSubheading: "Volg je collectie, AI-aanbevelingen en community-activiteit.",
+    latestBooks: "Nieuwste toevoegingen",
+    emptyLibraryCta: "Voeg je eerste boek toe om te beginnen!",
+    refresh: "Vernieuwen",
+    tryAgain: "Probeer opnieuw",
+  },
+};

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,0 +1,220 @@
+import { QueryClient } from "@tanstack/react-query";
+
+const API_BASE_URL = (import.meta.env?.VITE_API_BASE_URL as string | undefined) ?? "";
+
+const KNOWN_HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]);
+
+export class ApiError extends Error {
+  status: number;
+  data: unknown;
+
+  constructor(message: string, status: number, data: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+type ApiRequestInit = Omit<RequestInit, "body" | "method">;
+
+type NormalizedRequest = {
+  method: string;
+  path: string;
+  body: unknown;
+  init?: ApiRequestInit;
+};
+
+function normalizeRequest(
+  first: string,
+  second?: string | unknown,
+  third?: unknown,
+  fourth?: ApiRequestInit,
+): NormalizedRequest {
+  let method: string;
+  let path: string;
+  let body: unknown;
+  let init: ApiRequestInit | undefined;
+
+  if (first.startsWith("/")) {
+    path = first;
+
+    if (typeof second === "string" && !second.startsWith("/")) {
+      method = second;
+      body = third;
+      init = fourth;
+    } else {
+      method = "GET";
+      body = second;
+      init = third as ApiRequestInit | undefined;
+    }
+  } else {
+    method = first;
+    if (typeof second !== "string") {
+      throw new Error("Path must be provided when calling apiRequest with method first");
+    }
+    path = second;
+    body = third;
+    init = fourth;
+  }
+
+  method = method.toUpperCase();
+  if (!KNOWN_HTTP_METHODS.has(method)) {
+    throw new Error(`Unsupported HTTP method: ${method}`);
+  }
+
+  return { method, path, body, init };
+}
+
+function buildUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  if (!path.startsWith("/")) {
+    path = `/${path}`;
+  }
+
+  return `${API_BASE_URL}${path}`;
+}
+
+function prepareBody(body: unknown): BodyInit | undefined {
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  if (body instanceof FormData || body instanceof Blob || body instanceof ArrayBuffer || body instanceof URLSearchParams) {
+    return body as BodyInit;
+  }
+
+  if (typeof body === "string") {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
+async function handleError(response: Response): Promise<never> {
+  const contentType = response.headers.get("content-type");
+  let data: unknown;
+
+  if (contentType && contentType.includes("application/json")) {
+    try {
+      data = await response.json();
+    } catch (error) {
+      data = await response.text();
+    }
+  } else {
+    data = await response.text();
+  }
+
+  const message =
+    (typeof data === "object" && data !== null && "message" in data && typeof (data as Record<string, unknown>).message === "string"
+      ? (data as Record<string, unknown>).message
+      : undefined) ?? response.statusText ?? "Request failed";
+
+  throw new ApiError(message, response.status, data);
+}
+
+export async function apiRequest(
+  first: string,
+  second?: string | unknown,
+  third?: unknown,
+  fourth?: ApiRequestInit,
+): Promise<Response> {
+  const { method, path, body, init } = normalizeRequest(first, second, third, fourth);
+  const url = buildUrl(path);
+  const preparedBody = prepareBody(body);
+
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  if (preparedBody !== undefined && !(preparedBody instanceof FormData)) {
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    method,
+    credentials: init?.credentials ?? "include",
+    headers,
+    body: preparedBody,
+  });
+
+  if (!response.ok) {
+    await handleError(response);
+  }
+
+  return response;
+}
+
+function buildPathFromQueryKey(queryKey: readonly unknown[]): string {
+  if (queryKey.length === 0) {
+    throw new Error("Query key must not be empty");
+  }
+
+  const [base, extra] = queryKey;
+  if (typeof base !== "string") {
+    throw new Error("First query key entry must be a string path");
+  }
+
+  let path = base;
+
+  if (typeof extra === "string" || typeof extra === "number") {
+    path = `${base.replace(/\/$/, "")}/${extra}`;
+  } else if (extra && typeof extra === "object") {
+    const searchParams = new URLSearchParams();
+    Object.entries(extra as Record<string, unknown>).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          if (item !== undefined && item !== null) {
+            searchParams.append(key, String(item));
+          }
+        });
+      } else {
+        searchParams.append(key, String(value));
+      }
+    });
+
+    const queryString = searchParams.toString();
+    if (queryString) {
+      const separator = path.includes("?") ? "&" : "?";
+      path = `${path}${separator}${queryString}`;
+    }
+  }
+
+  return path;
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      queryFn: async ({ queryKey }) => {
+        const path = buildPathFromQueryKey(queryKey);
+        const response = await apiRequest("GET", path);
+        const contentType = response.headers.get("content-type");
+
+        if (contentType && contentType.includes("application/json")) {
+          return await response.json();
+        }
+
+        return await response.text();
+      },
+      retry: 1,
+      staleTime: 1000 * 30,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -1,0 +1,40 @@
+import NavigationBar from "@/components/navigation-bar";
+import AdminRevenueDashboard from "@/components/admin-revenue-dashboard";
+import AdvancedAnalytics from "@/components/advanced-analytics";
+import AffiliateMarketing from "@/components/affiliate-marketing";
+import AdvertisementComponent from "@/components/advertisement";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AdminDashboard() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-10">
+        <section className="space-y-2">
+          <h1 className="text-3xl font-black text-slate-900">Bestuursentrum</h1>
+          <p className="text-slate-600">
+            Monitor advertensie prestasie, gebruikersaktiwiteit en premium vennootskappe.
+          </p>
+        </section>
+
+        <AdminRevenueDashboard />
+
+        <AdvancedAnalytics />
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold text-slate-900">
+                Vennootskap prestasie
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <AffiliateMarketing />
+            </CardContent>
+          </Card>
+          <AdvertisementComponent position="sidebar" />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/events.tsx
+++ b/client/src/pages/events.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import NavigationBar from "@/components/navigation-bar";
+import EventAlertModal from "@/components/event-alert-modal";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { CalendarDays, MapPin, Users, Bell, Loader2, Check, XCircle } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import type { Event } from "@shared/schema";
+
+const eventTypeLabels: Record<string, string> = {
+  book_reading: "Boeklesing",
+  poetry_night: "Poësie aand",
+  author_talk: "Outeur gesprek",
+  book_club: "Boekklub",
+  workshop: "Werkswinkel",
+};
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("af-ZA", { style: "currency", currency: "ZAR" }).format(amount);
+}
+
+function formatDateRange(start: string, end?: string | null) {
+  const startDate = new Date(start);
+  const formatter = new Intl.DateTimeFormat("af-ZA", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const startLabel = formatter.format(startDate);
+  if (!end) return startLabel;
+  const endDate = new Date(end);
+  return `${startLabel} — ${formatter.format(endDate)}`;
+}
+
+export default function EventsPage() {
+  const [alertsOpen, setAlertsOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const eventsQuery = useQuery<Event[]>({
+    queryKey: ["/api/events"],
+  });
+
+  const myEventsQuery = useQuery({
+    queryKey: ["/api/events/my-events"],
+  });
+
+  const registeredMap = useMemo(() => {
+    const map = new Map<string, any>();
+    myEventsQuery.data?.forEach((event: any) => {
+      map.set(event.id, event);
+    });
+    return map;
+  }, [myEventsQuery.data]);
+
+  const registerMutation = useMutation({
+    mutationFn: async (eventId: string) => {
+      await apiRequest(`/api/events/${eventId}/register`, "POST");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/events/my-events"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/events"] });
+      toast({
+        title: "Geregistreer",
+        description: "Jy is aangemeld vir die gebeurtenis!",
+      });
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Kon nie registreer nie",
+        description: error instanceof Error ? error.message : "Probeer weer later.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: async (eventId: string) => {
+      await apiRequest(`/api/events/${eventId}/register`, "DELETE");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/events/my-events"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/events"] });
+      toast({
+        title: "Registrasie gekanselleer",
+        description: "Ons het jou plek vrygestel.",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Kon nie kanselleer nie",
+        description: "Probeer asseblief weer.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const isLoading = eventsQuery.isLoading || myEventsQuery.isLoading;
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-10">
+        <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-black text-slate-900">Literêre gebeurtenisse</h1>
+            <p className="text-slate-600">
+              Vind boekbekendstellings, poësie-aande en werkswinkels regoor Suid-Afrika.
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => setAlertsOpen(true)}>
+            <Bell className="h-4 w-4 mr-2" />
+            Stel kennisgewings op
+          </Button>
+        </header>
+
+        {isLoading && (
+          <div className="grid gap-4 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={index} className="h-64 animate-pulse bg-slate-200/70" />
+            ))}
+          </div>
+        )}
+
+        {eventsQuery.isError && (
+          <Card>
+            <CardContent className="py-10 text-center space-y-4">
+              <p className="text-slate-600">Kon nie gebeurtenisse laai nie.</p>
+              <Button onClick={() => eventsQuery.refetch()} variant="outline">
+                Probeer weer
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="space-y-4">
+            {eventsQuery.data?.map((event) => {
+              const registration = registeredMap.get(event.id);
+              const isRegistered = Boolean(registration);
+              const capacityLeft = event.maxAttendees
+                ? Math.max(0, event.maxAttendees - (event.currentAttendees || 0))
+                : null;
+
+              return (
+                <Card key={event.id}>
+                  <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <CardTitle className="text-2xl font-semibold text-slate-900">{event.title}</CardTitle>
+                      <CardDescription>{event.description}</CardDescription>
+                    </div>
+                    <div className="flex flex-wrap gap-2 items-center">
+                      <Badge variant="outline" className="bg-purple-100 text-purple-700 border-purple-200">
+                        {eventTypeLabels[event.eventType] ?? event.eventType}
+                      </Badge>
+                      <Badge variant="outline" className="bg-slate-100 text-slate-700 border-slate-200">
+                        {formatCurrency(event.price || 0)}
+                      </Badge>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid gap-3 sm:grid-cols-2 text-sm text-slate-600">
+                      <div className="flex items-start gap-2">
+                        <CalendarDays className="h-4 w-4 mt-1 text-slate-500" />
+                        <span>{formatDateRange(event.startDate, event.endDate)}</span>
+                      </div>
+                      <div className="flex items-start gap-2">
+                        <MapPin className="h-4 w-4 mt-1 text-slate-500" />
+                        <span>
+                          {event.venue}, {event.city}
+                        </span>
+                      </div>
+                      {event.featuredAuthor && (
+                        <div>
+                          <span className="font-medium text-slate-700">Uitgeligte outeur:</span>{" "}
+                          {event.featuredAuthor}
+                        </div>
+                      )}
+                      {event.featuredBook && (
+                        <div>
+                          <span className="font-medium text-slate-700">Uitgeligte boek:</span>{" "}
+                          {event.featuredBook}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+                      <div className="flex items-center gap-1">
+                        <Users className="h-4 w-4 text-slate-500" />
+                        <span>
+                          {event.currentAttendees ?? 0} geregistreer
+                          {event.maxAttendees ? ` / ${event.maxAttendees}` : ""}
+                        </span>
+                      </div>
+                      {capacityLeft !== null && (
+                        <Badge variant={capacityLeft > 0 ? "secondary" : "destructive"}>
+                          {capacityLeft > 0 ? `${capacityLeft} plekke oor` : "Vol"
+                          }
+                        </Badge>
+                      )}
+                    </div>
+
+                    <Separator />
+
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="text-sm text-slate-500">
+                        {event.organizer} • {event.organizerContact || "Geen kontak beskikbaar"}
+                      </div>
+                      {isRegistered ? (
+                        <div className="flex items-center gap-3">
+                          <Badge className="bg-green-100 text-green-700">
+                            <Check className="h-3 w-3 mr-1" /> Geregistreer
+                          </Badge>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-red-500 hover:text-red-600"
+                            onClick={() => cancelMutation.mutate(event.id)}
+                            disabled={cancelMutation.isPending}
+                          >
+                            {cancelMutation.isPending ? (
+                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                              <XCircle className="h-4 w-4 mr-2" />
+                            )}
+                            Kanselleer
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          onClick={() => registerMutation.mutate(event.id)}
+                          disabled={registerMutation.isPending || capacityLeft === 0}
+                        >
+                          {registerMutation.isPending ? (
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          ) : (
+                            <Users className="h-4 w-4 mr-2" />
+                          )}
+                          Bespreek plek
+                        </Button>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          <aside className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg font-semibold text-slate-900">My registrasies</CardTitle>
+                <CardDescription>
+                  Bestuur jou komende gebeurtenisse en hou rekord van vorige bywoning.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {myEventsQuery.data?.length ? (
+                  myEventsQuery.data.map((registration: any) => (
+                    <div key={registration.id} className="p-3 rounded-lg border border-slate-200 space-y-1">
+                      <p className="font-semibold text-slate-900">{registration.title}</p>
+                      <p className="text-sm text-slate-600">
+                        {formatDateRange(registration.startDate, registration.endDate)}
+                      </p>
+                      <Badge variant="outline" className="mt-1">
+                        Status: {registration.registrationStatus}
+                      </Badge>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-slate-600">Geen registrasies nog nie.</p>
+                )}
+              </CardContent>
+            </Card>
+          </aside>
+        </div>
+      </main>
+
+      <EventAlertModal open={alertsOpen} onOpenChange={setAlertsOpen} />
+    </div>
+  );
+}

--- a/client/src/pages/export.tsx
+++ b/client/src/pages/export.tsx
@@ -1,0 +1,33 @@
+import NavigationBar from "@/components/navigation-bar";
+import EnhancedExport from "@/components/enhanced-export";
+import AdvertisementComponent from "@/components/advertisement";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ExportPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-5xl mx-auto px-4 py-10 space-y-10">
+        <section className="space-y-2">
+          <h1 className="text-3xl font-black text-slate-900">Uitvoer en verslae</h1>
+          <p className="text-slate-600">
+            Skep professionele verslae van jou versameling vir versekeringsdoeleindes, deel of persoonlike argivering.
+          </p>
+        </section>
+
+        <EnhancedExport />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold text-slate-900">
+              Vennoot aanbevelings
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <AdvertisementComponent position="banner" />
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Book } from "@shared/schema";
+import { Plus, RefreshCcw } from "lucide-react";
+import NavigationBar from "@/components/navigation-bar";
+import StatsCards from "@/components/stats-cards";
+import AddBookDialog from "@/components/add-book-dialog";
+import BookCard from "@/components/book-card";
+import BookShareModal from "@/components/book-share-modal";
+import WishlistSection from "@/components/wishlist-section";
+import WishlistSearch from "@/components/wishlist-search";
+import SmartRecommendations from "@/components/smart-recommendations";
+import ReadingProgressTracker from "@/components/reading-progress-tracker";
+import AchievementsPanel from "@/components/achievements-panel";
+import AffiliateMarketing from "@/components/affiliate-marketing";
+import AdvertisementComponent from "@/components/advertisement";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useTranslation } from "@/components/language-provider";
+
+type StatsResponse = {
+  totalBooks: number;
+  wishlistCount: number;
+  rareBooks: number;
+  genreCount: number;
+  genreDistribution: Record<string, number>;
+};
+
+export default function Home() {
+  const t = useTranslation();
+  const [shareBook, setShareBook] = useState<Book | null>(null);
+
+  const statsQuery = useQuery<StatsResponse>({
+    queryKey: ["/api/stats"],
+  });
+
+  const booksQuery = useQuery<Book[]>({
+    queryKey: ["/api/books"],
+  });
+
+  const latestBooks = useMemo(() => {
+    if (!booksQuery.data) return [] as Book[];
+    return [...booksQuery.data].sort((a, b) => {
+      const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bDate = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bDate - aDate;
+    }).slice(0, 6);
+  }, [booksQuery.data]);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-12">
+        <section className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl sm:text-4xl font-black text-slate-900">
+              {t.dashboardHeading}
+            </h1>
+            <p className="text-slate-600 max-w-2xl">
+              {t.dashboardSubheading}
+            </p>
+          </div>
+          <AddBookDialog
+            trigger={
+              <Button size="lg" className="bg-purple-600 hover:bg-purple-700 text-white">
+                <Plus className="h-4 w-4 mr-2" />
+                Voeg boek by
+              </Button>
+            }
+          />
+        </section>
+
+        <StatsCards stats={statsQuery.data} />
+
+        <section className="grid gap-8 lg:grid-cols-3">
+          <div className="lg:col-span-2 space-y-8">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="text-xl font-semibold text-slate-900">
+                  {t.latestBooks}
+                </CardTitle>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => booksQuery.refetch()}
+                  disabled={booksQuery.isFetching}
+                  className="text-slate-500 hover:text-slate-900"
+                >
+                  <RefreshCcw className={`h-4 w-4 mr-2 ${booksQuery.isFetching ? "animate-spin" : ""}`} />
+                  {booksQuery.isFetching ? t.refresh : t.refresh}
+                </Button>
+              </CardHeader>
+              <CardContent>
+                {booksQuery.isLoading && (
+                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {Array.from({ length: 6 }).map((_, index) => (
+                      <Skeleton key={index} className="h-72 rounded-xl" />
+                    ))}
+                  </div>
+                )}
+
+                {booksQuery.isError && (
+                  <div className="flex flex-col items-center justify-center py-10 text-center gap-4">
+                    <p className="text-slate-600">Kon nie boeke laai nie.</p>
+                    <Button onClick={() => booksQuery.refetch()} variant="outline">
+                      {t.tryAgain}
+                    </Button>
+                  </div>
+                )}
+
+                {!booksQuery.isLoading && !booksQuery.isError && latestBooks.length === 0 && (
+                  <div className="flex flex-col items-center justify-center py-12 text-center gap-3">
+                    <p className="text-lg font-medium text-slate-700">{t.emptyLibraryCta}</p>
+                    <AddBookDialog
+                      trigger={
+                        <Button size="sm" variant="secondary" className="bg-purple-100 text-purple-700">
+                          <Plus className="h-4 w-4 mr-2" />
+                          Voeg nou by
+                        </Button>
+                      }
+                    />
+                  </div>
+                )}
+
+                {!booksQuery.isLoading && !booksQuery.isError && latestBooks.length > 0 && (
+                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {latestBooks.map((book) => (
+                      <BookCard key={book.id} book={book} onShare={setShareBook} />
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-xl font-semibold text-slate-900">
+                  Wenslys hulpmiddels
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <WishlistSection />
+                <WishlistSearch />
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="space-y-6">
+            <SmartRecommendations />
+            <ReadingProgressTracker />
+            <AchievementsPanel />
+            <AffiliateMarketing />
+            <AdvertisementComponent position="sidebar" />
+          </div>
+        </section>
+      </main>
+
+      {shareBook && (
+        <BookShareModal
+          open={Boolean(shareBook)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShareBook(null);
+            }
+          }}
+          book={shareBook}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,0 +1,109 @@
+import { Link } from "wouter";
+import { BookOpen, Sparkles, Users, Shield } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import LanguageSelector from "@/components/language-selector";
+import AdvertisementComponent from "@/components/advertisement";
+import { useTranslation } from "@/components/language-provider";
+
+const featureCards = [
+  {
+    icon: BookOpen,
+    title: "Afrikaanse katalogus",
+    description: "Volg elke boek in jou versameling met slim filters en AI-gegenereerde genre-insigte.",
+  },
+  {
+    icon: Sparkles,
+    title: "Slim aanbevelings",
+    description: "Ontvang persoonlike voorstelle wat jou smaak en leesvordering respekteer.",
+  },
+  {
+    icon: Users,
+    title: "Gemeenskap",
+    description: "Sluit by leesklubs, deel resensies en ontdek literêre gebeurtenisse naby jou.",
+  },
+  {
+    icon: Shield,
+    title: "Premium hulpmiddels",
+    description: "Berei waardeverslae, prysvergelykings en versamelaar-analise vir skaars boeke voor.",
+  },
+];
+
+export default function Landing() {
+  const t = useTranslation();
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col">
+      <header className="max-w-6xl mx-auto w-full px-4 py-6 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="h-12 w-12 rounded-2xl bg-gradient-to-br from-purple-500 via-pink-500 to-blue-500 flex items-center justify-center shadow-xl">
+            <span className="text-xl font-bold">BB</span>
+          </div>
+          <div>
+            <p className="font-black text-2xl tracking-tight">BURKEBOOKS</p>
+            <p className="text-xs text-slate-300 uppercase tracking-[0.3em]">Afrikaanse biblioteek</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <LanguageSelector />
+          <Button asChild variant="secondary">
+            <a href="/api/login">{t.login}</a>
+          </Button>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <section className="relative overflow-hidden py-24">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_60%)]" />
+          <div className="max-w-6xl mx-auto px-4 relative">
+            <div className="max-w-3xl space-y-6">
+              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black leading-tight text-slate-50">
+                {t.welcomeHeadline}
+              </h1>
+              <p className="text-lg sm:text-xl text-slate-300">
+                {t.welcomeSubheading}
+              </p>
+              <div className="flex flex-wrap gap-4">
+                <Button size="lg" className="shadow-lg shadow-purple-500/30" asChild>
+                  <a href="/api/login">{t.getStarted}</a>
+                </Button>
+                <Button size="lg" variant="outline" className="border-slate-700 text-slate-100" asChild>
+                  <Link href="#features">{t.discoverFeatures}</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="features" className="bg-slate-900/60 border-t border-slate-800">
+          <div className="max-w-6xl mx-auto px-4 py-16 grid gap-6 md:grid-cols-2">
+            {featureCards.map((feature) => (
+              <Card key={feature.title} className="bg-slate-900/80 border-slate-800">
+                <CardContent className="p-6 space-y-4">
+                  <feature.icon className="h-10 w-10 text-purple-400" />
+                  <div>
+                    <h3 className="text-xl font-semibold text-slate-100">{feature.title}</h3>
+                    <p className="text-sm text-slate-400">{feature.description}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-slate-900/80 border-t border-slate-800">
+          <div className="max-w-6xl mx-auto px-4 py-12 grid gap-6 md:grid-cols-3">
+            <AdvertisementComponent position="banner" className="md:col-span-3" />
+            <AdvertisementComponent position="sidebar" />
+            <AdvertisementComponent position="inline" />
+            <AdvertisementComponent position="footer" />
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-slate-800 py-6 text-sm text-center text-slate-500">
+        © {new Date().getFullYear()} BurkeBooks. Afrikaans biblioteek bestuur met liefde.
+      </footer>
+    </div>
+  );
+}

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,0 +1,17 @@
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-slate-950 text-slate-100 text-center px-6">
+      <p className="text-sm uppercase tracking-[0.3em] text-slate-500 mb-2">404</p>
+      <h1 className="text-4xl font-black mb-4">Bladsy nie gevind nie</h1>
+      <p className="text-slate-400 max-w-md mb-6">
+        Die bladsy waarna jy soek bestaan nie meer nie of is na 'n nuwe boekrak verskuif.
+      </p>
+      <Button asChild size="lg" variant="secondary">
+        <Link href="/">Keer terug huis toe</Link>
+      </Button>
+    </div>
+  );
+}

--- a/client/src/pages/premium.tsx
+++ b/client/src/pages/premium.tsx
@@ -1,0 +1,37 @@
+import NavigationBar from "@/components/navigation-bar";
+import PremiumSubscription from "@/components/premium-subscription";
+import AffiliateMarketing from "@/components/affiliate-marketing";
+import AdvertisementComponent from "@/components/advertisement";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function PremiumPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-5xl mx-auto px-4 py-10 space-y-10">
+        <section className="space-y-2 text-center">
+          <h1 className="text-3xl font-black text-slate-900">Premium lidmaatskap</h1>
+          <p className="text-slate-600">
+            Ontsluit AI-gedrewe insigte, advertensievrye lees en gevorderde versamelaar tools.
+          </p>
+        </section>
+
+        <PremiumSubscription />
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold text-slate-900">
+                Eksklusiewe vennootskappe
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <AffiliateMarketing />
+            </CardContent>
+          </Card>
+          <AdvertisementComponent position="sidebar" />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/price-alerts.tsx
+++ b/client/src/pages/price-alerts.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import NavigationBar from "@/components/navigation-bar";
+import PriceAlertModal from "@/components/price-alert-modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Loader2, Bell, Trash2 } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import type { Book } from "@shared/schema";
+
+function formatCurrency(value: number | null | undefined) {
+  const amount = typeof value === "number" ? value : 0;
+  return new Intl.NumberFormat("af-ZA", {
+    style: "currency",
+    currency: "ZAR",
+  }).format(amount);
+}
+
+export default function PriceAlertsPage() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [selectedBookId, setSelectedBookId] = useState<string | undefined>();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const alertsQuery = useQuery({
+    queryKey: ["/api/price-alerts"],
+  });
+
+  const booksQuery = useQuery<Book[]>({
+    queryKey: ["/api/books"],
+  });
+
+  const selectedBook = useMemo(
+    () => booksQuery.data?.find((book) => book.id === selectedBookId),
+    [booksQuery.data, selectedBookId],
+  );
+
+  const deleteAlertMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiRequest("DELETE", `/api/price-alerts/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/price-alerts"] });
+      toast({
+        title: "Waarskuwing verwyder",
+        description: "Ons sal jou nie meer vir hierdie boek in kennis stel nie.",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Kon nie verwyder nie",
+        description: "Probeer asseblief weer.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleCreateAlert = () => {
+    if (!selectedBook) {
+      toast({
+        title: "Kies 'n boek",
+        description: "Kies eers 'n boek uit jou biblioteek om 'n waarskuwing te skep.",
+      });
+      return;
+    }
+    setModalOpen(true);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-5xl mx-auto px-4 py-10 space-y-10">
+        <header className="space-y-3">
+          <h1 className="text-3xl font-black text-slate-900">Prys waarskuwings</h1>
+          <p className="text-slate-600">
+            Bly op hoogte wanneer jou gunsteling boeke afprys of beskikbaar raak by plaaslike handelaars.
+          </p>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="w-full sm:w-72">
+              <Select value={selectedBookId} onValueChange={setSelectedBookId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Kies 'n boek" />
+                </SelectTrigger>
+                <SelectContent>
+                  {booksQuery.data?.map((book) => (
+                    <SelectItem key={book.id} value={book.id}>
+                      {book.title} — {book.author}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button onClick={handleCreateAlert} disabled={!booksQuery.data || booksQuery.isLoading}>
+              <Bell className="h-4 w-4 mr-2" />
+              Skep waarskuwing
+            </Button>
+          </div>
+        </header>
+
+        {alertsQuery.isLoading && (
+          <div className="space-y-4">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Card key={index} className="h-32 animate-pulse bg-slate-200/70" />
+            ))}
+          </div>
+        )}
+
+        {alertsQuery.isError && (
+          <Card>
+            <CardContent className="py-10 text-center space-y-4">
+              <p className="text-slate-600">Kon nie waarskuwings laai nie.</p>
+              <Button onClick={() => alertsQuery.refetch()} variant="outline">
+                Probeer weer
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {alertsQuery.data?.length === 0 && !alertsQuery.isLoading && (
+          <Card>
+            <CardContent className="py-12 text-center space-y-4">
+              <p className="text-slate-600">Geen waarskuwings nie. Skep jou eerste waarskuwing hierbo.</p>
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid gap-4">
+          {alertsQuery.data?.map((alert: any) => (
+            <Card key={alert.id}>
+              <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <CardTitle className="text-xl font-semibold text-slate-900">
+                    {alert.bookTitle}
+                  </CardTitle>
+                  <CardDescription>deur {alert.author}</CardDescription>
+                </div>
+                <div className="flex flex-wrap gap-2 items-center">
+                  <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                    Teiken: {formatCurrency(alert.targetPrice)}
+                  </Badge>
+                  {alert.currentPrice && (
+                    <Badge variant="outline" className="bg-slate-100 text-slate-700 border-slate-200">
+                      Huidig: {formatCurrency(alert.currentPrice)}
+                    </Badge>
+                  )}
+                  {alert.savings && alert.savings > 0 && (
+                    <Badge className="bg-purple-100 text-purple-700">
+                      Spaar {formatCurrency(alert.savings)}
+                    </Badge>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                  <div>
+                    <span className="font-medium text-slate-700">Geskep:</span>{" "}
+                    {new Date(alert.createdAt).toLocaleDateString("af-ZA")}
+                  </div>
+                  <div>
+                    <span className="font-medium text-slate-700">Kennisgewings:</span>{" "}
+                    {alert.notificationEmail ? "E-pos" : ""}
+                    {alert.notificationEmail && alert.notificationSms ? " + " : ""}
+                    {alert.notificationSms ? "SMS" : !alert.notificationEmail ? "Geen" : ""}
+                  </div>
+                  {alert.lastNotifiedAt && (
+                    <div>
+                      <span className="font-medium text-slate-700">Laas kennis gegee:</span>{" "}
+                      {new Date(alert.lastNotifiedAt).toLocaleString("af-ZA")}
+                    </div>
+                  )}
+                </div>
+                <Separator />
+                <div className="flex items-center justify-end">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-500 hover:text-red-600"
+                    onClick={() => deleteAlertMutation.mutate(alert.id)}
+                    disabled={deleteAlertMutation.isPending}
+                  >
+                    {deleteAlertMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4 mr-2" />
+                    )}
+                    Verwyder
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </main>
+
+      {selectedBook && (
+        <PriceAlertModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          bookTitle={selectedBook.title}
+          author={selectedBook.author}
+          currentPrice={(selectedBook.currentValue || 0) / 100}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/price-comparison.tsx
+++ b/client/src/pages/price-comparison.tsx
@@ -1,0 +1,174 @@
+import NavigationBar from "@/components/navigation-bar";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Loader2, RefreshCcw, ShoppingCart, Sparkles } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("af-ZA", {
+    style: "currency",
+    currency: "ZAR",
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+export default function PriceComparison() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const comparisonsQuery = useQuery({
+    queryKey: ["/api/price-comparison"],
+  });
+
+  const compareMutation = useMutation({
+    mutationFn: async () => {
+      await apiRequest("POST", "/api/price-comparison/compare-wishlist");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/price-comparison"] });
+      toast({
+        title: "Vergelykings opgedateer",
+        description: "Ons het jou wenslys pryse herbereken.",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Kon nie vergelyk nie",
+        description: "Maak seker jou wenslys het boeke en probeer weer.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-10">
+        <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-black text-slate-900">Prysvergelykings</h1>
+            <p className="text-slate-600">
+              Monitor beste pryse vir jou wenslys en vind die beste winkelkeuses in Suid-Afrika.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="outline"
+              onClick={() => queryClient.invalidateQueries({ queryKey: ["/api/price-comparison"] })}
+              disabled={comparisonsQuery.isFetching}
+            >
+              <RefreshCcw className={`h-4 w-4 mr-2 ${comparisonsQuery.isFetching ? "animate-spin" : ""}`} />
+              Herlaai data
+            </Button>
+            <Button
+              onClick={() => compareMutation.mutate()}
+              disabled={compareMutation.isPending}
+              className="bg-green-600 hover:bg-green-700 text-white"
+            >
+              {compareMutation.isPending ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Sparkles className="h-4 w-4 mr-2" />
+              )}
+              Vergelyk wenslys
+            </Button>
+          </div>
+        </header>
+
+        {comparisonsQuery.isLoading && (
+          <div className="grid gap-6 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={index} className="h-64 animate-pulse bg-slate-200/70" />
+            ))}
+          </div>
+        )}
+
+        {comparisonsQuery.isError && (
+          <Card>
+            <CardContent className="py-12 text-center space-y-4">
+              <p className="text-slate-600">Kon nie pryse laai nie.</p>
+              <Button onClick={() => comparisonsQuery.refetch()} variant="outline">
+                Probeer weer
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {comparisonsQuery.data?.length === 0 && !comparisonsQuery.isLoading && (
+          <Card>
+            <CardContent className="py-12 text-center space-y-4">
+              <ShoppingCart className="h-10 w-10 text-slate-400 mx-auto" />
+              <p className="text-slate-600">Geen pryse beskikbaar nie. Vergelyk jou wenslys om te begin.</p>
+              <Button onClick={() => compareMutation.mutate()} disabled={compareMutation.isPending}>
+                Vergelyk nou
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {comparisonsQuery.data?.map((comparison: any) => (
+          <Card key={comparison.id}>
+            <CardHeader className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div>
+                <CardTitle className="text-2xl font-semibold text-slate-900">
+                  {comparison.bookTitle}
+                </CardTitle>
+                <p className="text-sm text-slate-500">deur {comparison.author}</p>
+              </div>
+              <div className="flex flex-wrap gap-3 items-center">
+                <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                  Beste prys: {formatCurrency(comparison.bestPrice)}
+                </Badge>
+                <Badge variant="outline" className="bg-slate-100 text-slate-700 border-slate-200">
+                  Gemiddeld: {formatCurrency(comparison.averagePrice)}
+                </Badge>
+                {comparison.savings > 0 && (
+                  <Badge className="bg-purple-100 text-purple-700">
+                    Spaar {formatCurrency(comparison.savings)}
+                  </Badge>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Winkel</TableHead>
+                    <TableHead>Beskikbaarheid</TableHead>
+                    <TableHead className="text-right">Prys</TableHead>
+                    <TableHead className="text-right">Versending</TableHead>
+                    <TableHead className="text-right">Totaal</TableHead>
+                    <TableHead className="text-right">Gradering</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {comparison.stores?.map((store: any) => (
+                    <TableRow key={store.id}>
+                      <TableCell>
+                        <div className="font-medium text-slate-900">{store.store}</div>
+                        {store.estimatedDelivery && (
+                          <p className="text-xs text-slate-500">Aflewering: {store.estimatedDelivery}</p>
+                        )}
+                      </TableCell>
+                      <TableCell>{store.availability || "Onbekend"}</TableCell>
+                      <TableCell className="text-right">{formatCurrency(store.price)}</TableCell>
+                      <TableCell className="text-right">{formatCurrency(store.shipping || 0)}</TableCell>
+                      <TableCell className="text-right font-semibold">{formatCurrency(store.totalPrice)}</TableCell>
+                      <TableCell className="text-right text-sm text-slate-500">
+                        {store.rating ? `${store.rating}/5` : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/recommendations.tsx
+++ b/client/src/pages/recommendations.tsx
@@ -1,0 +1,37 @@
+import NavigationBar from "@/components/navigation-bar";
+import SmartRecommendations from "@/components/smart-recommendations";
+import AffiliateMarketing from "@/components/affiliate-marketing";
+import AdvertisementComponent from "@/components/advertisement";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function RecommendationsPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-5xl mx-auto px-4 py-10 space-y-10">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-black text-slate-900">Aanbevelings laboratorium</h1>
+          <p className="text-slate-600">
+            Ontdek nuwe Afrikaanse boeke, verfyn jou voorkeure en stuur terugvoer aan ons AI.
+          </p>
+        </header>
+
+        <SmartRecommendations />
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold text-slate-900">
+                Vennootaanbevelings
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <AffiliateMarketing />
+            </CardContent>
+          </Card>
+          <AdvertisementComponent position="sidebar" />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/scanner.tsx
+++ b/client/src/pages/scanner.tsx
@@ -1,0 +1,51 @@
+import NavigationBar from "@/components/navigation-bar";
+import BarcodeScanner from "@/components/barcode-scanner";
+import CameraBookScanner from "@/components/camera-book-scanner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+
+export default function ScannerPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-5xl mx-auto px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-black text-slate-900">Skandeerder laboratorium</h1>
+          <p className="text-slate-600">
+            Gebruik jou kamera om boeke te skandeer en outomaties by jou versameling te voeg.
+          </p>
+        </header>
+
+        <Alert className="bg-blue-50 border-blue-200 text-blue-700">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Wenk</AlertTitle>
+          <AlertDescription>
+            Maak seker jy gee kameratoegang toe wanneer jy die skandeerders gebruik vir die beste ervaring.
+          </AlertDescription>
+        </Alert>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold text-slate-900">Skandeer opsies</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tabs defaultValue="barcode">
+              <TabsList>
+                <TabsTrigger value="barcode">Barcode skandeerder</TabsTrigger>
+                <TabsTrigger value="camera">Omslag analise</TabsTrigger>
+              </TabsList>
+              <TabsContent value="barcode" className="pt-6">
+                <BarcodeScanner />
+              </TabsContent>
+              <TabsContent value="camera" className="pt-6">
+                <CameraBookScanner />
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/social.tsx
+++ b/client/src/pages/social.tsx
@@ -1,0 +1,24 @@
+import NavigationBar from "@/components/navigation-bar";
+import SocialFeatures from "@/components/social-features";
+import AdvertisementComponent from "@/components/advertisement";
+
+export default function SocialPage() {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <NavigationBar />
+      <main className="max-w-6xl mx-auto px-4 py-10 space-y-10">
+        <section className="space-y-2">
+          <h1 className="text-3xl font-black text-slate-900">Gemeenskapsplein</h1>
+          <p className="text-slate-600">
+            Deel resensies, sluit by boekklubs aan en neem deel aan uitdagings saam met ander Afrikaans lesers.
+          </p>
+        </section>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <SocialFeatures />
+          <AdvertisementComponent position="sidebar" />
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add query client utilities and translations for the client app
- implement a shared authentication hook and error helpers
- create landing, dashboard, admin, premium, recommendations, social, export, price comparison, price alerts, events, and scanner pages for the React client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efcea154e88323a73f11fd692d3359